### PR TITLE
fix(chatbox): auto-scroll to latest message when overflow

### DIFF
--- a/frontend/src/components/ChatBox.jsx
+++ b/frontend/src/components/ChatBox.jsx
@@ -6,6 +6,7 @@ import "../styles/ChatBox.css";
 
 export default function ChatBox({ messages = [], onSelect, collapse }) {
   const previousMessages = useRef([]);
+  const chatContainerRef = useRef(null); // 🔹 NUEVO
   const audioRef = useRef(
     typeof Audio !== "undefined" ? new Audio("/sounds/pop.mp3") : null
   );
@@ -37,6 +38,16 @@ export default function ChatBox({ messages = [], onSelect, collapse }) {
     previousMessages.current = messages;
   }, [messages]);
 
+  // 🔹 AUTO-SCROLL AL ÚLTIMO MENSAJE (FIX BUG)
+  useEffect(() => {
+    if (isCollapsed) return;
+
+    const container = chatContainerRef.current;
+    if (!container) return;
+
+    container.scrollTop = container.scrollHeight;
+  }, [messages, isCollapsed]);
+
   return (
     <div className="chatbox-wrapper">
       
@@ -48,16 +59,17 @@ export default function ChatBox({ messages = [], onSelect, collapse }) {
         <span className="chatbox-title">Coffe</span>
 
         <span
-          className={`chatbox-chevron ${
-            isCollapsed ? "collapsed" : ""
-          }`}
+          className={`chatbox-chevron ${isCollapsed ? "collapsed" : ""}`}
         >
           ▾
         </span>
       </div>
 
       {/* BODY */}
-      <div className={`chatbox-container ${isCollapsed ? "collapsed" : ""}`}>
+      <div
+        ref={chatContainerRef} // 🔹 NUEVO
+        className={`chatbox-container ${isCollapsed ? "collapsed" : ""}`}
+      >
         {messages.map((msg, index) => {
           // ---- OPCIONES ----
           if (msg.options) {


### PR DESCRIPTION
## Summary
Fixes an issue where the chatbox does not automatically scroll to the latest message when the message list exceeds the container height.

This ensures that new incoming messages are always visible without requiring manual user scrolling, restoring the expected chat behavior.

## Changes
- Added automatic scroll-to-bottom behavior on message updates
- Ensured scroll logic runs only when chatbox is expanded
- Improved overall chat usability during long conversations

## Related Issue
Closes #5
