### PR TITLE
feat(questionnaire): add restart option after recommendation

### DIFF
--- a/frontend/src/components/RecommendationCard.jsx
+++ b/frontend/src/components/RecommendationCard.jsx
@@ -1,18 +1,19 @@
-// src/components/RecommendationCard.jsx
 import { motion } from "framer-motion";
 import coffees from "../data/coffees";
+import OptionButton from "./OptionButton";
+import { RotateCcw, LogOut } from "lucide-react";
 
-export default function RecommendationCard({ coffee }) {
+export default function RecommendationCard({
+  coffee,
+  onRestart,
+  onExit,
+}) {
   if (!coffee) return null;
 
-  // Extraer ID sin importar si viene como string o como objeto
   const coffeeId = typeof coffee === "string" ? coffee : coffee.id;
-
-  // Buscar el café real en coffees.js
   const finalCoffee = coffees.find(c => c.id === coffeeId);
 
   if (!finalCoffee) {
-    console.log("❌ No se encontró el café con id:", coffeeId);
     return <p className="text-white">No se encontró la bebida.</p>;
   }
 
@@ -55,6 +56,21 @@ export default function RecommendationCard({ coffee }) {
           </ul>
         </div>
       )}
+
+      {/* --- ACTIONS --- */}
+      <div className="mt-6 flex flex-col gap-3">
+        <OptionButton
+          label="Restart questionnaire"
+          icon={RotateCcw}
+          onClick={onRestart}
+        />
+
+        <OptionButton
+          label="Change knowledge level"
+          icon={LogOut}
+          onClick={onExit}
+        />
+      </div>
     </motion.div>
   );
 }

--- a/frontend/src/context/UserAnswersContext.jsx
+++ b/frontend/src/context/UserAnswersContext.jsx
@@ -8,7 +8,7 @@ export function UserAnswersProvider({ children }) {
   const [answers, setAnswers] = useState([]);
   const [currentQuestionIndex, setCurrentQuestionIndex] = useState(0);
 
-// ✔ Agregar respuesta, reemplazando si ya existe
+// Agregar respuesta, reemplazando si ya existe
 const addAnswer = (answer) => {
   setAnswers((prev) => {
     // si ya existe una respuesta para esta pregunta → reemplazar
@@ -17,27 +17,32 @@ const addAnswer = (answer) => {
   });
 };
 
-
-  // ⭐️ ✔ goNextQuestion seguro (evita pasarte del total)
+  // goNextQuestion seguro (evita pasarte del total)
   const goNextQuestion = (totalQuestions) => {
     setCurrentQuestionIndex((prev) =>
       prev + 1 < totalQuestions ? prev + 1 : prev
     );
   };
 
-  // ✔ Reiniciar flujo completo
+  // Reiniciar cuestionario manteniendo el nivel
+  const restartQuestionnaire = () => {
+    setAnswers([]);
+    setCurrentQuestionIndex(0);
+  };
+
+  // Reiniciar flujo completo
   const resetFlow = () => {
     setLevel(null);
     setAnswers([]);
     setCurrentQuestionIndex(0);
   };
 
-  // ⭐️ ✔ Saber si ya terminó correctamente
+  // Saber si ya terminó correctamente
   const isFinished = (totalQuestions) => {
     return currentQuestionIndex >= totalQuestions - 1;
   };
 
-  // ⭐️ ✔ Reset automático al cambiar nivel
+  // Reset automático al cambiar nivel
   useEffect(() => {
     if (level !== null) {
       setAnswers([]);
@@ -54,6 +59,7 @@ const addAnswer = (answer) => {
         addAnswer,
         currentQuestionIndex,
         goNextQuestion,
+        restartQuestionnaire,
         resetFlow,
         isFinished,
       }}

--- a/frontend/src/pages/Assistant.jsx
+++ b/frontend/src/pages/Assistant.jsx
@@ -1,6 +1,7 @@
 // src/pages/Assistant.jsx
 import { useNavigate } from "react-router-dom";
 import { useState, useEffect } from "react";
+import { useUserAnswers } from "../context/UserAnswersContext";
 import ChatBox from "../components/ChatBox";
 import RecommendationCard from "../components/RecommendationCard";
 import useChatFlow from "../hooks/useChatFlow";
@@ -15,6 +16,22 @@ export default function Assistant() {
     answers
   } = useChatFlow();
 
+  const { 
+    restartQuestionnaire, 
+    resetFlow 
+  } = useUserAnswers();
+
+  const handleRestartQuestionnaire = () => {
+    restartQuestionnaire();   // reinicia lógica
+    setMessages([]);          // 🔥 limpia chat
+    setInitialStep(0);        // reinicia intro
+  };
+  
+  const handleExitToHome = () => {
+    resetFlow();              // borra nivel + flujo
+    navigate("/");            // vuelve al home
+  };
+  
   const navigate = useNavigate();
 
   const TYPING_TIME = 1200;
@@ -140,7 +157,11 @@ export default function Assistant() {
         {/* RECOMENDACIÓN FINAL */}
         {finished && recommendation && (
           <div className="mt-10">
-            <RecommendationCard coffee={recommendation} />
+            <RecommendationCard
+              coffee={recommendation}
+              onRestart={handleRestartQuestionnaire}
+              onExit={handleExitToHome}
+            />
           </div>
         )}
       </div>


### PR DESCRIPTION
## Summary
Adds action buttons to the recommendation card allowing users to restart the questionnaire or change their knowledge level without reloading the page.

## Changes
- Added Restart questionnaire action to retake the flow using the same knowledge level
- Added Change knowledge level option to reset the flow and return to level selection
- Implemented questionnaire reset logic while preserving or clearing user state accordingly
- Adjusted chat collapse behavior after questionnaire completion for better UX

## Related Issue
Closes #2 