### PR TITLE
ui(menu): add spacing between navbar and Menu content

### DIFF
--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -38,7 +38,7 @@ export default function Menu() {
       <div className="bg-bottom-fade" />
 
       {/* Contenido */}
-      <div className="relative z-10 max-w-6xl mx-auto py-16">
+      <div className="relative z-10 max-w-6xl mx-auto pt-24 sm:pt-32 md:pt-40 pb-16">
         <h1 className="text-4xl sm:text-5xl font-extrabold text-white drop-shadow-xl">
           Nuestra Carta
         </h1>


### PR DESCRIPTION
### Summary
Added vertical spacing between the navbar and the main content on the Menu page to prevent overlap and improve visual layout. Adjusted padding for responsive breakpoints.

### Changes

- Increased top padding (pt) on the Menu content container.
- Added responsive adjustments for mobile, tablet, and desktop.
- Verified that content no longer overlaps navbar.
- No other behavior or layout changes.

### Related Issue
Closes #37  

