### PR TITLE
ui(menu): add entrance animations to menu content

### DIFF
--- a/frontend/src/components/menu/MenuCard.jsx
+++ b/frontend/src/components/menu/MenuCard.jsx
@@ -5,7 +5,7 @@ export default function MenuCard({ item, onSelect }) {
     <motion.div
       className="
         relative
-        bg-white/90 backdrop-blur-sm
+        bg-white/75 backdrop-blur-sm
         rounded-2xl
         p-2 sm:p-2
         cursor-pointer

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -23,17 +23,14 @@ export default function Home() {
     >
 
       {/* ---- VIDEO DE FONDO ---- */}
-<video 
-  src="/videos/cafeteria.mp4"
-  className="fixed inset-0 w-full h-[100dvh] min-h-[100dvh] object-cover"
-  autoPlay 
-  muted 
-  loop 
-  playsInline 
-/>
-
-
-
+      <video 
+        src="/videos/cafeteria.mp4"
+        className="fixed inset-0 w-full h-[100dvh] min-h-[100dvh] object-cover"
+        autoPlay 
+        muted 
+        loop 
+        playsInline 
+      />
 
       {/* ---- OVERLAY DESDE CSS ---- */}
       <div className="bg-overlay" />

--- a/frontend/src/pages/Menu.jsx
+++ b/frontend/src/pages/Menu.jsx
@@ -5,6 +5,7 @@ import MenuItemModal from "../components/menu/MenuItemModal";
 import "../styles/globals/background.css";
 import "../styles/globals/scroll.css"
 import { buildNavMenu } from "../features/menu/navMenu.adapter";
+import { motion } from "framer-motion";
 
 const { categories, items } = buildNavMenu();
 
@@ -31,27 +32,45 @@ export default function Menu() {
       {/* Content */}
       <div className="relative z-10 max-w-6xl mx-auto pt-32 sm:pt-32 md:pt-40 h-full flex flex-col">
         {/* Header */}
-        <h1 className="text-4xl sm:text-5xl font-extrabold text-white drop-shadow-xl">
-          Nuestra Carta
-        </h1>
-        <p className="text-gray-100 mt-1 mb-4">
-          Explora nuestros cafés y frapés
-        </p>
+        <motion.div
+          initial={{ opacity: 0, y: 16 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.5, ease: "easeOut" }}
+        >
+          <h1 className="text-4xl sm:text-5xl font-extrabold text-white drop-shadow-xl">
+            Nuestra Carta
+          </h1>
+          <p className="text-gray-100 mt-1 mb-4">
+            Explora nuestros cafés y frapés
+          </p>
+        </motion.div>
 
-        <CategorySelector
-          categories={categories}
-          active={category}
-          onChange={setCategory}
-        />
+        <motion.div
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}   
+          transition={{ duration: 0.45, delay: 0.15, ease: "easeOut" }}
+        >
+          <CategorySelector
+            categories={categories}
+            active={category}
+            onChange={setCategory}
+          />
+        </motion.div>
 
         {/* MenuWrapper */}
         <div className="flex-1 overflow-y-auto overflow-x-hidden scroll-hidden relative scroll-fade-vertical">
-          <div className="pb-16 relative">
-            <MenuGrid
-              items={items[category] ?? []}
-              onSelect={setSelectedItem}
+          <motion.div
+            className="pb-16 relative"
+            initial={{ opacity: 0, y: 20 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ duration: 0.5, delay: 0.25, ease: "easeOut" }}
+          >
+             <MenuGrid
+             items={items[category] ?? []}
+             onSelect={setSelectedItem}
             />
-          </div>
+          </motion.div>
+
         </div>
       </div>
 


### PR DESCRIPTION
### Summary
The Menu page previously rendered all content statically, making the transition feel abrupt compared to Home.
This PR introduces subtle entrance animations to improve visual continuity and perceived quality.

### Changes
- Animated Menu header (title + subtitle) on page load
- Added entrance animation to CategorySelector
- Animated MenuGrid container (fade + slight translate)
- Animations run only on page load (no re-animation on scroll)

### Related Issue
Closes #70 
