### PR TITLE
refactor(chatbox): convert ChatBox into a pure UI component

### DIFF
--- a/frontend/src/components/chatbox/ChatBox.jsx
+++ b/frontend/src/components/chatbox/ChatBox.jsx
@@ -1,40 +1,28 @@
-// frontend\src\components\chatbox\ChatBox.jsx
-import React, { useRef, useState, useEffect } from "react";
+import React, { useRef } from "react";
 import ChatMessage from "./chatMessage";
-import { useUserAnswers } from "../../context/UserAnswersContext";
 import useChatSound from "../../hooks/assistant/useChatSound";
 import useChatAutoScroll from "../../hooks/assistant/useChatAutoScroll";
 import "../../styles/features/chatbox/ChatBox.css";
 
-export default function ChatBox({ messages = [], onSelect, collapse }) {
+export default function ChatBox({
+  messages = [],
+  onSelect,
+  collapsed,
+  onToggleCollapse,
+  levelLabel
+}) {
+
   const chatContainerRef = useRef(null);
-  const [isCollapsed, setIsCollapsed] = useState(false);
-
-  const { level } = useUserAnswers();
-
-  const levelLabelMap = {
-    beginner: "Principiante",
-    intermediate: "Intermedio",
-    expert: "Experto",
-  };
-
-  const levelLabel = level ? levelLabelMap[level] : null;
-
-  useEffect(() => {
-    if (collapse) {
-      setTimeout(() => setIsCollapsed(true), 150);
-    }
-  }, [collapse]);
 
   useChatSound(messages);
-  useChatAutoScroll(messages, chatContainerRef, isCollapsed);
+  useChatAutoScroll(messages, chatContainerRef, collapsed);
 
   return (
     <div className="chatbox-wrapper">
 
       <div
         className="chatbox-header"
-        onClick={() => setIsCollapsed(prev => !prev)}
+        onClick={onToggleCollapse}
       >
         <span className="chatbox-title">Coffe</span>
 
@@ -45,7 +33,7 @@ export default function ChatBox({ messages = [], onSelect, collapse }) {
         )}
 
         <span
-          className={`chatbox-chevron ${isCollapsed ? "collapsed" : ""}`}
+          className={`chatbox-chevron ${collapsed ? "collapsed" : ""}`}
         >
           ▾
         </span>
@@ -53,7 +41,7 @@ export default function ChatBox({ messages = [], onSelect, collapse }) {
 
       <div
         ref={chatContainerRef}
-        className={`chatbox-container ${isCollapsed ? "collapsed" : ""}`}
+        className={`chatbox-container ${collapsed ? "collapsed" : ""}`}
       >
         {messages.map((msg) => (
           <ChatMessage
@@ -63,6 +51,7 @@ export default function ChatBox({ messages = [], onSelect, collapse }) {
           />
         ))}
       </div>
+
     </div>
   );
 }

--- a/frontend/src/context/UserAnswersContext.jsx
+++ b/frontend/src/context/UserAnswersContext.jsx
@@ -1,4 +1,4 @@
-// src/context/UserAnswersContext.jsx
+// frontend\src\context\UserAnswersContext.jsx
 import { createContext, useContext, useState, useEffect } from "react";
 
 const UserAnswersContext = createContext();

--- a/frontend/src/hooks/assistant/useChatAutoScroll.js
+++ b/frontend/src/hooks/assistant/useChatAutoScroll.js
@@ -1,3 +1,4 @@
+// frontend\src\hooks\assistant\useChatAutoScroll.js
 import { useEffect } from "react";
 
 export default function useChatAutoScroll(

--- a/frontend/src/hooks/assistant/useChatSound.js
+++ b/frontend/src/hooks/assistant/useChatSound.js
@@ -1,3 +1,4 @@
+// frontend\src\hooks\assistant\useChatSound.js
 import { useEffect, useRef } from "react";
 
 export default function useChatSound(messages) {

--- a/frontend/src/pages/Assistant.jsx
+++ b/frontend/src/pages/Assistant.jsx
@@ -15,6 +15,16 @@ import { motion, AnimatePresence } from "framer-motion";
 export default function Assistant() {
   const navigate = useNavigate();
 
+  const { level } = useUserAnswers();
+
+  const levelLabelMap = {
+    beginner: "Principiante",
+    intermediate: "Intermedio",
+    expert: "Experto",
+  };
+
+  const levelLabel = level ? levelLabelMap[level] : null;
+
   const {
     currentQuestion,
     finished,
@@ -51,6 +61,8 @@ export default function Assistant() {
     clearTyping,
     timing: CHAT_TIMING
   });
+  
+  const [isChatCollapsed, setIsChatCollapsed] = useState(false);
 
   const [conversationState, setConversationState] = useState("intro");
 
@@ -88,6 +100,12 @@ export default function Assistant() {
     generateRecommendation(answers);
   
   }, [finished, answers]);
+
+  useEffect(() => {
+    if (finished) {
+      setTimeout(() => setIsChatCollapsed(true), 150);
+    }
+  }, [finished]);
     
   function handleSelect(value, label) {
     if (!currentQuestion) return;
@@ -140,13 +158,16 @@ export default function Assistant() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ duration: 0.4 }}
         >
-          <ChatBox
-            messages={messages}
-            onSelect={handleSelect}
-            collapse={finished}
-          />
+        <ChatBox
+          messages={messages}
+          onSelect={handleSelect}
+          collapsed={isChatCollapsed}
+          onToggleCollapse={() =>
+            setIsChatCollapsed(prev => !prev)
+          }
+          levelLabel={levelLabel}
+        />
         </motion.div>
-
         <AnimatePresence>
           {finished && recommendation && (
             <motion.div


### PR DESCRIPTION
### Summary
Refactors ChatBox to become a pure UI component by removing internal state and moving interaction logic to the parent controller.

### Changes

* Removed internal state management from ChatBox
* Moved collapse and interaction logic to the parent controller
* Converted ChatBox into a controlled component
* Standardized ChatBox API through props (messages, collapsed, onToggle, onSelect)
* Ensured compatibility with the normalized message schema

### Impact

* No visible UI changes
* Improves separation of concerns between UI and chat logic
* Makes ChatBox easier to reuse and test
* Simplifies future chat engine evolution

### Related Issue
Closes #84 